### PR TITLE
Preserve default context on start from named state

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -411,7 +411,7 @@ export class Interpreter<
         ? this.machine.initialState
         : initialState instanceof State
         ? this.machine.resolveState(initialState)
-        : this.machine.resolveState(State.from(initialState));
+        : this.machine.resolveState(State.from(initialState, this.machine.context));
     });
 
     if (this.options.devTools) {


### PR DESCRIPTION
When an initial state is not passed to `service.start()`, `machine.initialState` is used, which is filled in with a lot of details, particularly a copy of the default `machine.context`.

When an initial state is passed as a `State` object, it is loaded directly, and it is assume that this comes with the desired `.context` value filled in.

But when an initial state is passed as a named state, like `interpret(machine).start("COMMENT_FORM")`, the resulting state has `.context === undefined` because nothing ever sets it. `State.from()`, which handles loading a string state to a full state object, already had an option to attach a context, but it was not used in this case.

Discovered during https://github.com/davidkpiano/xstate/issues/432